### PR TITLE
Align podspec dependency version constraints with SPM

### DIFF
--- a/WalletConnectWeb3.podspec
+++ b/WalletConnectWeb3.podspec
@@ -22,8 +22,8 @@ HTTP RPC interface provided by this library or a custom RPC interface
 
   s.swift_versions = '5.1.3', '5.1.2', '5.0', '5.1', '5.3'
 
-  s.dependency 'BigInt', '~> 5.0.0'
-  s.dependency 'CryptoSwift', '~> 1.0.0'
+  s.dependency 'BigInt', '~> 5.0'
+  s.dependency 'CryptoSwift', '~> 1.0'
   s.dependency 'secp256k1.swift', '~> 0.1.1'
 
   s.source_files  = "Sources/Core/*/*.swift"


### PR DESCRIPTION
Removing the patch version from `BigInt` & `CryptoSwift` podspec dependencies to align with SPM's "up to the next major version"

This also makes it easier to include in projects where those dependencies already are includes but with slightly different version constraints.